### PR TITLE
Use <a> tags for links.

### DIFF
--- a/src/app/components/comment/comment.component.css
+++ b/src/app/components/comment/comment.component.css
@@ -10,3 +10,7 @@
 .card-footer {
   background-color: #3a3a3a;
 }
+
+[mat-chip] {
+  cursor: pointer;
+}

--- a/src/app/components/comment/comment.component.html
+++ b/src/app/components/comment/comment.component.html
@@ -3,10 +3,23 @@
     <div class="row">
       <div class="col-10 col-md-6 col-lg-4 col-xl-3">
         <mat-chip-list class="mat-chip-list-stacked text-center">
-          <mat-chip color="primary" selected (click)="goToLink(comment.commentLink)"
-          >Комментарий - {{ comment.system }}</mat-chip
+          <a [href]="comment.commentLink"
+             mat-chip
+             target="_blank"
+             selected
+             selectable="false"
           >
-          <mat-chip color="warn" (click)="goToLink(comment.workLink)" selected>{{ comment.workName }}</mat-chip>
+            Комментарий - {{ comment.system }}
+          </a>
+          <a [href]="comment.workLink"
+             mat-chip
+             color="warn"
+             target="_blank"
+             selected
+             selectable="false"
+          >
+            {{comment.workName}}
+          </a>
         </mat-chip-list>
       </div>
     </div>

--- a/src/app/components/comment/comment.component.ts
+++ b/src/app/components/comment/comment.component.ts
@@ -24,8 +24,4 @@ export class CommentComponent implements OnInit {
       }
     }
   }
-
-  goToLink(url: string) {
-    window.open(url, '_blank');
-  }
 }


### PR DESCRIPTION
This improves accessibility and keyboard navigation.

Also mark all chips as selectable="false", as "selected" is only used for styles, and selectability isn't actually needed here.